### PR TITLE
water build: preserve multipolygon ring topology - islands are land (#44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt install -y libegl1
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-qt pytest-env pytest-cov
-        pip install -e .[qt,svs]
+        pip install -e .[qt,svs,watertools]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/docs/water_database.md
+++ b/docs/water_database.md
@@ -73,6 +73,50 @@ The build is currently driven by hand from the Windows dev box
 because the shapefiles are downloaded manually. Resulting sqlite
 file is scp'd to the Pi at `/home/wpballard/pyEfis/water/`.
 
+## Multi-ring polygons — island holes (#44)
+
+A multipolygon's interior rings are LAND (islands): the Florida Keys
+are holes in the ocean polygons that surround them. The original
+ingest emitted every ring as its own filled polygon and tessellated
+single-ring only, so an island was painted as water twice over — the
+outer ring's fill covered it, and its own coastline became a filled
+ocean polygon (KEYW rendered as ocean; issue #44).
+
+The builder now preserves ring topology:
+
+- Rings are classified by winding (shapefile convention, which the
+  data preserves: outer rings are clockwise in (lon, lat) = negative
+  shoelace signed area; holes counter-clockwise = positive) and each
+  hole is grouped under the smallest outer ring containing it.
+- One `water_polygons` row is stored per OUTER ring. Its `vertices`
+  BLOB holds the outer ring followed by each hole ring; a new
+  nullable `rings` BLOB (little-endian uint16 ring END offsets, earcut
+  convention) records the ring boundaries. `rings` is NULL for
+  single-ring rows — the overwhelming majority.
+- `triangles` is tessellated hole-aware (earcut's ring list), so the
+  GPU fill excludes the islands with no renderer change.
+- Safety fallbacks: a single-ring shape imports as an outer whatever
+  its winding (Natural Earth / text-format sources); a multi-ring
+  shape with no clockwise ring fills every ring (reversed-winding
+  source, the pre-#44 behavior); a hole contained by no outer is
+  dropped, never filled.
+- Decimation (`--max-vertices`) applies PER RING at build time, and
+  `WaterDB` never re-decimates multi-ring rows on load — a stride
+  across concatenated rings would corrupt both the ring offsets and
+  the triangle indices.
+
+Reader/consumer contract: `WaterPolygon.rings` is the decoded offset
+list (None on single-ring rows and pre-#44 databases — those stay
+fully readable). Triangle-based consumers (the SVS GL water layer)
+need no ring handling. Outline/fill consumers must not treat
+`vertices` as one drawable ring: fill even-odd per ring (the moving
+map's `_draw_water`) or use `WaterPolygon.outer_vertices`.
+
+Old databases keep working against new code (probe-based, like the
+`triangles` column). New databases read under OLD code degrade only
+on multi-ring rows (the concatenated vertex list draws as one
+outline); ship the pack rebuild together with the code update.
+
 ## Pi-side wiring
 
 `virtual_vfr.yaml` in the screen YAML carries:

--- a/docs/water_database.md
+++ b/docs/water_database.md
@@ -90,11 +90,30 @@ The builder now preserves ring topology:
   hole is grouped under the smallest outer ring containing it.
 - One `water_polygons` row is stored per OUTER ring. Its `vertices`
   BLOB holds the outer ring followed by each hole ring; a new
-  nullable `rings` BLOB (little-endian uint16 ring END offsets, earcut
+  nullable `rings` BLOB (little-endian ring END offsets, earcut
   convention) records the ring boundaries. `rings` is NULL for
   single-ring rows — the overwhelming majority.
 - `triangles` is tessellated hole-aware (earcut's ring list), so the
   GPU fill excludes the islands with no renderer change.
+- **Index dtype rule (dense cells):** both the `triangles` and
+  `rings` BLOBs are uint16 for rows of <= 65535 total vertices and
+  uint32 beyond. The dtype is implied by the row's vertex count
+  (which the reader already derives from the `vertices` BLOB length),
+  so no schema flag is needed. Before this rule, rows past the uint16
+  ceiling silently DROPPED all their holes — the lower Florida Keys
+  cell (3,322 island rings, > 65535 vertices at any realistic
+  per-ring cap) lost every island, which kept #44 alive at the KEYW
+  test-case location.
+- **Hole verification (build time):** after tessellation, every hole
+  ring's interior (even-odd scanline sample points) is checked
+  against the row's fill triangles — decimation can corrupt a ring
+  into something self-intersecting or outer-crossing that earcut
+  fills instead of subtracting. On failure the per-ring decimation
+  cap escalates (doubling to 512, then the raw source rings); if raw
+  still fails, fill triangles whose centroid lands in a hole are
+  stripped (biased toward land — painting an island as water is the
+  dangerous direction). Unresolved rows warn on stderr and
+  `import_shapefile` prints escalated / stripped / unresolved counts.
 - Safety fallbacks: a single-ring shape imports as an outer whatever
   its winding (Natural Earth / text-format sources); a multi-ring
   shape with no clockwise ring fills every ring (reversed-winding
@@ -113,9 +132,12 @@ need no ring handling. Outline/fill consumers must not treat
 map's `_draw_water`) or use `WaterPolygon.outer_vertices`.
 
 Old databases keep working against new code (probe-based, like the
-`triangles` column). New databases read under OLD code degrade only
-on multi-ring rows (the concatenated vertex list draws as one
-outline); ship the pack rebuild together with the code update.
+`triangles` column; old rows never exceed 65535 vertices, so the
+uint16 decode path applies to all of them). New databases read under
+OLD code degrade on multi-ring rows (the concatenated vertex list
+draws as one outline), and an old reader would mis-decode a dense
+row's uint32 blobs as uint16 — deploy the code update FIRST, then
+ship the pack rebuild.
 
 ## Pi-side wiring
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,13 @@ svs = [
     "numpy>=1.24",
     "PyOpenGL>=3.1.6",
 ]
+# Build-time-only deps for the water-pack builder (tools/build_water_db.py)
+# and its tests: earcut tessellation + shapefile reading. Never needed at
+# runtime — the renderer reads the pre-computed sqlite.
+watertools = [
+    "mapbox-earcut>=1.0",
+    "pyshp>=2.3",
+]
 
 [project.scripts]
 pyefis = "pyefis.main:main"

--- a/src/pyefis/instruments/ai/svs.py
+++ b/src/pyefis/instruments/ai/svs.py
@@ -1577,8 +1577,18 @@ class SVSRenderer:
             else:
                 surface_ft = sampled_ft.get(i, 0.0)
 
-            n_v = len(poly.vertices)
+            verts = poly.vertices
             tri_idx = poly.triangles
+            if tri_idx is None and poly.rings:
+                # Multi-ring (outer + island holes) row without stored
+                # triangles — the builder guarantees rings => triangles,
+                # so this is defensive. Fan the outer ring alone: a fan
+                # across the concatenated rings would paint the island
+                # holes as water (#44).
+                verts = poly.outer_vertices
+            n_v = len(verts)
+            if n_v < 3:
+                continue
             if tri_idx is None:
                 # Pre-tessellation DB — fall back to a fan from v0.
                 # Correct for convex polygons, approximation for
@@ -1593,7 +1603,7 @@ class SVSRenderer:
             # Clip indices defensively; the build tool may emit one
             # malformed entry on a tessellation edge case.
             np.clip(tri_idx, 0, n_v - 1, out=tri_idx)
-            verts_np = np.asarray(poly.vertices, dtype=np.float32)
+            verts_np = np.asarray(verts, dtype=np.float32)
             picked = verts_np[tri_idx]   # (n_idx, 2) — fancy indexing
             buf = np.empty((picked.shape[0], 3), dtype=np.float32)
             buf[:, 0:2] = picked

--- a/src/pyefis/instruments/ai/water_db.py
+++ b/src/pyefis/instruments/ai/water_db.py
@@ -23,7 +23,12 @@ Schema (built by tools/build_water_db.py):
         max_lon   REAL NOT NULL,
         kind      TEXT NOT NULL,   -- 'ocean' | 'lake' | 'river' | ...
         elev_ft   REAL,            -- known surface elev (lakes); NULL for ocean
-        vertices  BLOB NOT NULL    -- struct-packed <dd>... = list of (lat, lon)
+        vertices  BLOB NOT NULL,   -- struct-packed <dd>... = list of (lat, lon)
+        triangles BLOB,            -- uint16 LE triangle indices (may be absent)
+        rings     BLOB             -- uint16 LE ring END offsets for multi-ring
+                                   -- (outer + island holes) rows; NULL for
+                                   -- single-ring rows and absent in pre-#44
+                                   -- databases
     )
     INDEX idx_bbox ON water_polygons(min_lat, max_lat, min_lon, max_lon)
 """
@@ -54,10 +59,26 @@ class WaterPolygon:
     # convert to whatever it wants. None when the build tool was
     # older than the tessellation schema bump.
     triangles : list | None = None
+    # Ring END offsets into ``vertices`` for multi-ring polygons
+    # (outer ring first, then each island hole — earcut convention).
+    # None for single-ring polygons. When present, ``triangles`` was
+    # tessellated hole-aware, so triangle-based consumers need no
+    # ring handling; outline/fill consumers must use even-odd filling
+    # or ``outer_vertices`` — the raw ``vertices`` list concatenates
+    # all rings and is NOT one drawable outline.
+    rings     : list | None = None
 
     @property
     def is_ocean(self) -> bool:
         return self.kind == "ocean"
+
+    @property
+    def outer_vertices(self) -> list:
+        """The outer ring alone — the whole ``vertices`` list for a
+        single-ring polygon."""
+        if self.rings:
+            return self.vertices[:self.rings[0]]
+        return self.vertices
 
 
 class WaterDB:
@@ -84,6 +105,7 @@ class WaterDB:
         # scale queries against the 878k-polygon OSM dataset.
         self._has_rtree = False
         self._has_triangles = False
+        self._has_rings = False
         if self._path is None or not self._path.is_file():
             log.info("WaterDB: %s not found — water rendering disabled",
                      self._path)
@@ -125,6 +147,18 @@ class WaterDB:
                     "renderer will fan-tessellate at draw time "
                     "(slower; rebuild with current build_water_db.py "
                     "for pre-tessellation)")
+            # Probe for the rings column (the #44 island-hole fix).
+            # Older DBs without it are all single-ring; islands inside
+            # water polygons render as water until the pack is rebuilt.
+            try:
+                self._con.execute(
+                    "SELECT rings FROM water_polygons LIMIT 0")
+                self._has_rings = True
+            except sqlite3.OperationalError:
+                log.info(
+                    "WaterDB: no rings column found; island holes in "
+                    "water polygons render as water (rebuild with "
+                    "current build_water_db.py — issue #44)")
         except Exception as e:
             log.warning("WaterDB: cannot open %s: %s", self._path, e)
             self._con = None
@@ -176,9 +210,11 @@ class WaterDB:
             # the B-tree fallback at OSM dataset scale.
             tri_expr = ("p.triangles" if self._has_triangles
                         else "NULL AS triangles")
+            rings_expr = ("p.rings" if self._has_rings
+                          else "NULL AS rings")
             sql = (
                 "SELECT p.id, p.kind, p.elev_ft, p.vertices, "
-                f"       {tri_expr}, "
+                f"       {tri_expr}, {rings_expr}, "
                 "       p.min_lat, p.max_lat, p.min_lon, p.max_lon "
                 "FROM water_polygons p "
                 "JOIN water_rtree r ON r.id = p.id "
@@ -197,9 +233,11 @@ class WaterDB:
         else:
             tri_expr = ("triangles" if self._has_triangles
                         else "NULL AS triangles")
+            rings_expr = ("rings" if self._has_rings
+                          else "NULL AS rings")
             sql = (
                 "SELECT id, kind, elev_ft, vertices, "
-                f"       {tri_expr}, "
+                f"       {tri_expr}, {rings_expr}, "
                 "       min_lat, max_lat, min_lon, max_lon "
                 "FROM water_polygons "
                 "WHERE max_lat > ? AND min_lat < ? "
@@ -216,12 +254,19 @@ class WaterDB:
             cur = self._con.execute(sql, params)
         cap = self._max_vertices
         for r in cur:
+            rings = _decode_rings(r["rings"])
+            # Multi-ring rows are never re-decimated on load: stride
+            # decimation across concatenated rings would corrupt the
+            # ring topology AND the pre-tessellated triangle indices.
+            # The build-time per-ring cap is the bound for these rows.
             yield WaterPolygon(
                 id=r["id"],
                 kind=(r["kind"] or "").strip().lower(),
                 elev_ft=r["elev_ft"],
-                vertices=_decode_vertices(r["vertices"], cap),
-                triangles=_decode_triangles(r["triangles"]))
+                vertices=_decode_vertices(r["vertices"],
+                                          None if rings else cap),
+                triangles=_decode_triangles(r["triangles"]),
+                rings=rings)
 
 
 def _decode_vertices(blob: bytes, max_vertices: int | None = None) -> list:
@@ -268,6 +313,17 @@ def _decode_triangles(blob):
     list of ints (3 entries per triangle). Returns None when the
     polygon was inserted by a pre-tessellation build of the DB and
     has no triangles stored."""
+    if not blob:
+        return None
+    n = len(blob) // 2
+    return list(struct.unpack(f"<{n}H", blob))
+
+
+def _decode_rings(blob):
+    """Unpack a uint16 little-endian ring-end-offset blob into a list
+    of ints (earcut convention: entry k is the END offset of ring k in
+    the vertices list; ring 0 is the outer ring, the rest are island
+    holes). Returns None for single-ring polygons and pre-#44 DBs."""
     if not blob:
         return None
     n = len(blob) // 2

--- a/src/pyefis/instruments/ai/water_db.py
+++ b/src/pyefis/instruments/ai/water_db.py
@@ -24,11 +24,16 @@ Schema (built by tools/build_water_db.py):
         kind      TEXT NOT NULL,   -- 'ocean' | 'lake' | 'river' | ...
         elev_ft   REAL,            -- known surface elev (lakes); NULL for ocean
         vertices  BLOB NOT NULL,   -- struct-packed <dd>... = list of (lat, lon)
-        triangles BLOB,            -- uint16 LE triangle indices (may be absent)
-        rings     BLOB             -- uint16 LE ring END offsets for multi-ring
-                                   -- (outer + island holes) rows; NULL for
-                                   -- single-ring rows and absent in pre-#44
-                                   -- databases
+        triangles BLOB,            -- LE triangle indices (may be absent).
+                                   -- uint16 for rows of <= 65535 vertices,
+                                   -- uint32 beyond (dense multi-ring cells) —
+                                   -- the dtype is implied by the row's vertex
+                                   -- count, mirrored by the builder
+        rings     BLOB             -- LE ring END offsets for multi-ring
+                                   -- (outer + island holes) rows; same
+                                   -- uint16/uint32 vertex-count rule as
+                                   -- ``triangles``. NULL for single-ring rows
+                                   -- and absent in pre-#44 databases
     )
     INDEX idx_bbox ON water_polygons(min_lat, max_lat, min_lon, max_lon)
 """
@@ -254,7 +259,12 @@ class WaterDB:
             cur = self._con.execute(sql, params)
         cap = self._max_vertices
         for r in cur:
-            rings = _decode_rings(r["rings"])
+            # The stored vertex count picks the triangle/ring index
+            # dtype (uint16 <= 65535 vertices, uint32 beyond) — dense
+            # multi-ring cells overflow uint16 and the builder mirrors
+            # this exact rule, so the row is self-describing.
+            n_verts = len(r["vertices"]) // 16 if r["vertices"] else 0
+            rings = _decode_rings(r["rings"], n_verts)
             # Multi-ring rows are never re-decimated on load: stride
             # decimation across concatenated rings would corrupt the
             # ring topology AND the pre-tessellated triangle indices.
@@ -265,7 +275,7 @@ class WaterDB:
                 elev_ft=r["elev_ft"],
                 vertices=_decode_vertices(r["vertices"],
                                           None if rings else cap),
-                triangles=_decode_triangles(r["triangles"]),
+                triangles=_decode_triangles(r["triangles"], n_verts),
                 rings=rings)
 
 
@@ -308,23 +318,41 @@ def encode_vertices(vertices) -> bytes:
     return bytes(buf)
 
 
-def _decode_triangles(blob):
-    """Unpack a uint16 little-endian triangle-index blob into a flat
-    list of ints (3 entries per triangle). Returns None when the
-    polygon was inserted by a pre-tessellation build of the DB and
-    has no triangles stored."""
+def _decode_triangles(blob, n_vertices):
+    """Unpack a little-endian triangle-index blob into a flat list of
+    ints (3 entries per triangle). Returns None when the polygon was
+    inserted by a pre-tessellation build of the DB and has no
+    triangles stored.
+
+    The index dtype is implied by the row's vertex count: uint16 for
+    <= 65535 vertices, uint32 beyond. Dense multi-ring cells (the
+    lower Florida Keys cell carries 3,322 island rings) overflow
+    uint16; the old builder dropped their holes entirely rather than
+    widen the indices (#44 residual). The builder applies the same
+    threshold, so no schema flag is needed."""
     if not blob:
         return None
+    if n_vertices > 65535:
+        if len(blob) % 4:
+            return None     # not a uint32 blob — treat as untessellated
+        n = len(blob) // 4
+        return list(struct.unpack(f"<{n}I", blob))
     n = len(blob) // 2
     return list(struct.unpack(f"<{n}H", blob))
 
 
-def _decode_rings(blob):
-    """Unpack a uint16 little-endian ring-end-offset blob into a list
-    of ints (earcut convention: entry k is the END offset of ring k in
-    the vertices list; ring 0 is the outer ring, the rest are island
-    holes). Returns None for single-ring polygons and pre-#44 DBs."""
+def _decode_rings(blob, n_vertices):
+    """Unpack a little-endian ring-end-offset blob into a list of ints
+    (earcut convention: entry k is the END offset of ring k in the
+    vertices list; ring 0 is the outer ring, the rest are island
+    holes). Returns None for single-ring polygons and pre-#44 DBs.
+    Same uint16/uint32 vertex-count rule as ``_decode_triangles``."""
     if not blob:
         return None
+    if n_vertices > 65535:
+        if len(blob) % 4:
+            return None
+        n = len(blob) // 4
+        return list(struct.unpack(f"<{n}I", blob))
     n = len(blob) // 2
     return list(struct.unpack(f"<{n}H", blob))

--- a/src/pyefis/instruments/map/layers/terrain.py
+++ b/src/pyefis/instruments/map/layers/terrain.py
@@ -15,7 +15,8 @@ import threading
 
 import numpy as np
 from PyQt6.QtCore import QPointF, QRectF, Qt
-from PyQt6.QtGui import QBrush, QColor, QImage, QPainter, QPolygonF
+from PyQt6.QtGui import (QBrush, QColor, QImage, QPainter, QPainterPath,
+                         QPolygonF)
 
 from pyefis.instruments.ai.camera import M_PER_DEG_LAT
 from pyefis.instruments.map.layers import MapLayer, register_layer
@@ -287,7 +288,23 @@ class TerrainLayer(MapLayer):
                 pts = [QPointF((lo - lon0) * px_per_deg_lon + half_px,
                                (lat0 - la) * px_per_deg_lat + half_px)
                        for la, lo in poly.vertices]
-                if len(pts) >= 3:
+                rings = getattr(poly, "rings", None)
+                if rings:
+                    # Multi-ring row (outer + island holes, #44):
+                    # even-odd fill leaves the hole rings — islands —
+                    # unpainted. The vertices list concatenates all
+                    # rings, so a plain drawPolygon would be garbage.
+                    path = QPainterPath()
+                    path.setFillRule(Qt.FillRule.OddEvenFill)
+                    start = 0
+                    for end in rings:
+                        ring_pts = pts[start:end]
+                        if len(ring_pts) >= 3:
+                            path.addPolygon(QPolygonF(ring_pts))
+                            path.closeSubpath()
+                        start = end
+                    p.drawPath(path)
+                elif len(pts) >= 3:
                     p.drawPolygon(QPolygonF(pts))
         except Exception:
             import logging

--- a/tests/instruments/ai/test_svs.py
+++ b/tests/instruments/ai/test_svs.py
@@ -487,6 +487,69 @@ class TestWaterDB:
             assert abs(la - la2) < 1e-12
             assert abs(lo - lo2) < 1e-12
 
+    def test_multi_ring_row_decodes_rings_and_skips_redecimation(
+            self, tmp_path):
+        """#44: a multi-ring row (outer ring + island hole) decodes its
+        ring topology, is never re-decimated on load (stride decimation
+        across concatenated rings would corrupt the ring offsets and
+        the pre-tessellated triangle indices), and exposes the outer
+        ring via ``outer_vertices``."""
+        import sqlite3
+        import struct
+        from pyefis.instruments.ai.water_db import (
+            WaterDB, encode_vertices)
+        outer = [(24.0, -82.5), (25.0, -82.5),
+                 (25.0, -81.0), (24.0, -81.0)]
+        hole = [(24.5, -81.8), (24.5, -81.7),
+                (24.6, -81.7), (24.6, -81.8)]
+        path = tmp_path / "water.sqlite"
+        con = sqlite3.connect(str(path))
+        con.execute("""
+            CREATE TABLE water_polygons (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                min_lat   REAL NOT NULL, max_lat   REAL NOT NULL,
+                min_lon   REAL NOT NULL, max_lon   REAL NOT NULL,
+                kind      TEXT NOT NULL, elev_ft   REAL,
+                vertices  BLOB NOT NULL, triangles BLOB, rings BLOB)
+        """)
+        con.execute(
+            "INSERT INTO water_polygons "
+            "(min_lat, max_lat, min_lon, max_lon, kind, elev_ft, "
+            " vertices, triangles, rings) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (24.0, 25.0, -82.5, -81.0, "ocean", None,
+             encode_vertices(outer + hole), None,
+             struct.pack("<2H", 4, 8)))
+        con.commit()
+        con.close()
+
+        # Cap below the 8 stored vertices: a legacy single-ring row
+        # would be decimated; the multi-ring row must come back intact.
+        db = WaterDB(path, max_vertices=6)
+        assert db.ready is True
+        polys = list(db.polygons_in_range(24.5, -81.7, 60.0))
+        assert len(polys) == 1
+        poly = polys[0]
+        assert poly.rings == [4, 8]
+        assert len(poly.vertices) == 8
+        assert poly.outer_vertices == outer
+
+    def test_pre_rings_db_reads_with_rings_none(self, tmp_path):
+        """A pre-#44 database (no rings column) stays readable; every
+        polygon reports ``rings is None`` and single-ring behavior is
+        unchanged."""
+        from pyefis.instruments.ai.water_db import WaterDB
+        path = self._build_db(tmp_path, [
+            ("ocean", None, [(34.0, -120.5), (34.0, -119.5),
+                             (34.5, -119.5), (34.5, -120.5)]),
+        ])
+        db = WaterDB(path)
+        assert db.ready is True
+        polys = list(db.polygons_in_range(34.4, -119.8, 30.0))
+        assert len(polys) == 1
+        assert polys[0].rings is None
+        assert polys[0].outer_vertices == polys[0].vertices
+
 
 class TestSVSWaterRendering:
     """``_draw_water`` overlays water polygons on top of the terrain
@@ -580,6 +643,58 @@ class TestSVSWaterRendering:
                    0.0, 0.0, 270.0, 12.0)
         finally:
             p.end()
+
+    def test_collect_water_multi_ring_without_triangles_fans_outer_only(
+            self, tmp_path):
+        """#44 defensive path: a multi-ring row with no stored triangles
+        (the builder guarantees rings => triangles, so only a corrupt or
+        hand-built DB gets here) must fan the OUTER ring alone — a fan
+        across the concatenated rings would paint the island hole as
+        water."""
+        import sqlite3
+        import struct
+        from pyefis.instruments.ai.water_db import encode_vertices
+        outer = [(24.0, -82.5), (25.0, -82.5),
+                 (25.0, -81.0), (24.0, -81.0)]
+        hole = [(24.5, -81.8), (24.5, -81.7),
+                (24.6, -81.7), (24.6, -81.8)]
+        path = tmp_path / "water.sqlite"
+        con = sqlite3.connect(str(path))
+        con.execute("""
+            CREATE TABLE water_polygons (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                min_lat   REAL NOT NULL, max_lat   REAL NOT NULL,
+                min_lon   REAL NOT NULL, max_lon   REAL NOT NULL,
+                kind      TEXT NOT NULL, elev_ft   REAL,
+                vertices  BLOB NOT NULL, triangles BLOB, rings BLOB)
+        """)
+        con.execute(
+            "INSERT INTO water_polygons "
+            "(min_lat, max_lat, min_lon, max_lon, kind, elev_ft, "
+            " vertices, triangles, rings) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (24.0, 25.0, -82.5, -81.0, "ocean", None,
+             encode_vertices(outer + hole), None,
+             struct.pack("<2H", 4, 8)))
+        con.commit()
+        con.close()
+
+        root = _make_tile_dir(tmp_path, 24, -82, elevation=0)
+        r = SVSRenderer({
+            "enabled": True, "tile_path": str(root),
+            "water_db_path": str(path),
+        })
+        tris = r._collect_water_sync(24.5, -81.7, 30.0)
+        assert tris is not None
+        # Every emitted vertex comes from the outer ring; the hole's
+        # vertices never appear in the fan. (Coordinates ride through
+        # float32, so compare at 3 decimals.)
+        emitted = {(round(float(v[0]), 3), round(float(v[1]), 3))
+                   for v in tris[:, :2]}
+        outer_set = {(round(la, 3), round(lo, 3)) for la, lo in outer}
+        hole_set = {(round(la, 3), round(lo, 3)) for la, lo in hole}
+        assert emitted <= outer_set
+        assert not (emitted & hole_set)
 
 
 class TestSVSGLFallback:

--- a/tests/instruments/test_moving_map.py
+++ b/tests/instruments/test_moving_map.py
@@ -130,6 +130,66 @@ def test_terrain_water_rasterized_into_window(qapp):
     assert not (land.blue() > land.red() and land.blue() > land.green())
 
 
+class _FakeIslandWaterDB:
+    """Stub WaterDB: one multi-ring lake (#44) — outer ring with an
+    island hole at its centre, rings = uint16-style end offsets as the
+    real WaterDB decodes them."""
+
+    ready = True
+
+    def __init__(self, lat0, lon0):
+        d, hd = 0.03, 0.01              # outer / island half-sides
+        outer = [(lat0 - d, lon0 - d), (lat0 - d, lon0 + d),
+                 (lat0 + d, lon0 + d), (lat0 + d, lon0 - d)]
+        hole = [(lat0 - hd, lon0 - hd), (lat0 - hd, lon0 + hd),
+                (lat0 + hd, lon0 + hd), (lat0 + hd, lon0 - hd)]
+        self._poly = type("P", (), {})()
+        self._poly.vertices = outer + hole
+        self._poly.rings = [4, 8]
+        self._poly.kind = "lake"
+
+    def polygons_in_range(self, lat, lon, range_nm,
+                          min_bbox_diag_deg=None, drop_ocean=False):
+        yield self._poly
+
+
+def test_terrain_water_island_hole_stays_land(qapp):
+    """#44: a multi-ring water polygon paints even-odd — the water ring
+    goes blue, the island hole inside it stays land-coloured instead of
+    being flooded by the outer ring's fill."""
+    lat0, lon0 = 34.5, -120.5
+    lay = TerrainLayer()
+    lay._cache = _LandCache()
+    lay._water = _FakeIslandWaterDB(lat0, lon0)
+
+    class Owner:
+        _alt_ft = 3000.0
+    lay._owner = Owner
+
+    x = moving_map.MapTransform(lat0, lon0, 10.0, 0.0, 400, 400, 0.5)
+    key = lay._key(x)
+    img, meta = lay._render((key, x.lat0, x.lon0, x.range_nm,
+                             x.w, x.h, x.cy))
+    clat, clon, mpp = meta
+    n = img.width()
+
+    def px(la, lo):
+        half = (n - 1) / 2.0
+        M = 111320.0
+        cx = (lo - clon) * M * np.cos(np.radians(clat)) / mpp + half
+        cy = (clat - la) * M / mpp + half
+        return img.pixelColor(int(round(cx)), int(round(cy)))
+
+    water = px(lat0, lon0 + 0.02)         # between hole and outer ring
+    island = px(lat0, lon0)               # island centre
+    outside = px(lat0, lon0 + 0.05)       # beyond the outer ring
+    assert water.blue() > water.red() and water.blue() > water.green()
+    assert not (island.blue() > island.red()
+                and island.blue() > island.green())
+    assert not (outside.blue() > outside.red()
+                and outside.blue() > outside.green())
+
+
 class _FakeHighwayDB:
     """Stub HighwayDB: one motorway segment strictly NORTH of the
     ownship (so orientation tests can discriminate sides -- a through

--- a/tests/tools/test_build_water_db.py
+++ b/tests/tools/test_build_water_db.py
@@ -289,6 +289,104 @@ class TestShapefileImport:
                                          poly.triangles)
 
 
+class TestHoleVerification:
+    """Residual A of #44: per-ring decimation can hand earcut a self-
+    intersecting or outer-crossing hole, and earcut then FILLS it
+    (54/770 hole interiors covered in a Keys probe build). The builder
+    now verifies every hole interior against the stored triangles,
+    escalates the decimation cap on failure, and strips hole-covering
+    triangles as a last resort."""
+
+    def _bad_fan(self):
+        import numpy as np
+        # The outer square fan-filled with the hole ignored — covers
+        # the island, exactly what a corrupted hole degenerates to.
+        return np.asarray([0, 1, 2, 0, 2, 3], dtype=np.uint16)
+
+    def test_interior_points_are_inside_their_ring(self):
+        concave = [(24.50, -81.80), (24.50, -81.70), (24.60, -81.70),
+                   (24.60, -81.74), (24.52, -81.74), (24.52, -81.76),
+                   (24.60, -81.76), (24.60, -81.80)]
+        for ring in (HOLE_CCW, OUTER_CW, concave):
+            pts = bw._ring_interior_points(ring)
+            assert pts
+            for lat, lon in pts:
+                assert bw._point_in_ring(lat, lon, ring)
+
+    def test_detector_flags_fill_that_covers_hole(self):
+        all_verts = OUTER_CW + HOLE_CCW
+        assert bw._covered_hole_indices(all_verts, [4, 8],
+                                        self._bad_fan()) == [0]
+
+    def test_detector_passes_hole_aware_fill(self):
+        all_verts = OUTER_CW + HOLE_CCW
+        tri = bw.tessellate_polygon(all_verts, [4, 8])
+        assert tri is not None
+        assert bw._covered_hole_indices(all_verts, [4, 8], tri) == []
+
+    def test_escalation_recovers_from_bad_tessellation(self, tmp_path,
+                                                       monkeypatch):
+        # First attempt returns the hole-covering fan; the retry (at
+        # the doubled cap) delegates to the real earcut. The bad fill
+        # must be detected and never stored.
+        real = bw.tessellate_polygon
+        calls = {"n": 0}
+
+        def flaky(verts, ring_ends=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return self._bad_fan()
+            return real(verts, ring_ends)
+
+        monkeypatch.setattr(bw, "tessellate_polygon", flaky)
+        path, con = _open_db(tmp_path)
+        stats = {}
+        assert bw.insert_polygon(con, "ocean", None, OUTER_CW,
+                                 max_vertices=32, holes=[HOLE_CCW],
+                                 stats=stats)
+        con.commit()
+        con.close()
+        assert stats.get("escalated") == 1
+        assert "stripped" not in stats and "unresolved" not in stats
+        verts, tris, rings = _decode(_fetch_rows(path)[0])
+        assert rings is not None and len(rings) == 2
+        assert not _covered_by_triangles(*ISLAND_PT, verts, tris)
+        assert _covered_by_triangles(*WATER_PT, verts, tris)
+
+    def test_strip_fallback_when_raw_rings_still_fail(self, tmp_path,
+                                                      monkeypatch):
+        # Every attempt (including the raw source rings) yields a
+        # correct hole-aware fill PLUS one rogue triangle inside the
+        # hole: the escalation ladder exhausts, then the strip repair
+        # removes the rogue triangle and the row verifies clean.
+        import numpy as np
+        real = bw.tessellate_polygon
+
+        def always_rogue(verts, ring_ends=None):
+            good = real(verts, ring_ends)
+            # Vertices 4, 5, 6 are hole vertices — the rogue triangle
+            # sits inside the island.
+            return np.concatenate(
+                [good, np.asarray([4, 5, 6], dtype=good.dtype)])
+
+        monkeypatch.setattr(bw, "tessellate_polygon", always_rogue)
+        path, con = _open_db(tmp_path)
+        stats = {}
+        assert bw.insert_polygon(con, "ocean", None, OUTER_CW,
+                                 max_vertices=32, holes=[HOLE_CCW],
+                                 stats=stats)
+        con.commit()
+        con.close()
+        assert stats.get("escalated") == 1    # ladder ran first
+        assert stats.get("stripped") == 1
+        assert "unresolved" not in stats
+        verts, tris, rings = _decode(_fetch_rows(path)[0])
+        assert rings is not None and len(rings) == 2
+        assert len(tris) % 3 == 0
+        assert not _covered_by_triangles(*ISLAND_PT, verts, tris)
+        assert _covered_by_triangles(*WATER_PT, verts, tris)
+
+
 def _dense_multipolygon():
     """A synthetic dense cell: one outer box + a 20x15 grid of
     220-vertex circular island holes = 66,004 vertices, past the

--- a/tests/tools/test_build_water_db.py
+++ b/tests/tools/test_build_water_db.py
@@ -68,9 +68,42 @@ def _fetch_rows(path):
 def _decode(row):
     from pyefis.instruments.ai.water_db import (
         _decode_rings, _decode_triangles, _decode_vertices)
+    n_verts = len(row["vertices"]) // 16
     return (_decode_vertices(row["vertices"]),
-            _decode_triangles(row["triangles"]),
-            _decode_rings(row["rings"]))
+            _decode_triangles(row["triangles"], n_verts),
+            _decode_rings(row["rings"], n_verts))
+
+
+def _covered_points_mask(points, vertices, triangles):
+    """Vectorized ``_covered_by_triangles`` for large sweeps: a boolean
+    per (lat, lon) point, True when any stored fill triangle covers it.
+    Per-triangle bboxes prefilter the exact sign tests so a full sweep
+    of a dense cell (10^5 triangles) stays test-suite fast."""
+    import numpy as np
+    v = np.asarray(vertices, dtype=np.float64)
+    t = np.asarray(triangles, dtype=np.int64).reshape(-1, 3)
+    a, b, c = v[t[:, 0]], v[t[:, 1]], v[t[:, 2]]
+    lat_min = np.minimum(np.minimum(a[:, 0], b[:, 0]), c[:, 0])
+    lat_max = np.maximum(np.maximum(a[:, 0], b[:, 0]), c[:, 0])
+    lon_min = np.minimum(np.minimum(a[:, 1], b[:, 1]), c[:, 1])
+    lon_max = np.maximum(np.maximum(a[:, 1], b[:, 1]), c[:, 1])
+    out = np.zeros(len(points), dtype=bool)
+    for i, (lat, lon) in enumerate(points):
+        cand = np.nonzero((lat_min <= lat) & (lat_max >= lat)
+                          & (lon_min <= lon) & (lon_max >= lon))[0]
+        if cand.size == 0:
+            continue
+        aa, bb, cc = a[cand], b[cand], c[cand]
+        d1 = ((lon - bb[:, 1]) * (aa[:, 0] - bb[:, 0])
+              - (aa[:, 1] - bb[:, 1]) * (lat - bb[:, 0]))
+        d2 = ((lon - cc[:, 1]) * (bb[:, 0] - cc[:, 0])
+              - (bb[:, 1] - cc[:, 1]) * (lat - cc[:, 0]))
+        d3 = ((lon - aa[:, 1]) * (cc[:, 0] - aa[:, 0])
+              - (cc[:, 1] - aa[:, 1]) * (lat - aa[:, 0]))
+        neg = (d1 < 0) | (d2 < 0) | (d3 < 0)
+        pos = (d1 > 0) | (d2 > 0) | (d3 > 0)
+        out[i] = bool((~(neg & pos)).any())
+    return out
 
 
 def _covered_by_triangles(lat, lon, vertices, triangles):
@@ -254,3 +287,119 @@ class TestShapefileImport:
         assert max(poly.triangles) < len(poly.vertices)
         assert not _covered_by_triangles(*ISLAND_PT, poly.vertices,
                                          poly.triangles)
+
+
+def _dense_multipolygon():
+    """A synthetic dense cell: one outer box + a 20x15 grid of
+    220-vertex circular island holes = 66,004 vertices, past the
+    uint16 index ceiling (65,535 — the old builder silently DROPPED
+    every hole of such a row; the real lower-Keys cell lost its
+    3,322 islands that way, #44's oracle-gate residual B). Returns
+    (outer, holes, hole_centers)."""
+    import math
+    outer = [(24.0, -82.0), (25.0, -82.0), (25.0, -81.0), (24.0, -81.0)]
+    if bw.ring_signed_area(outer) > 0:
+        outer.reverse()
+    holes = []
+    centers = []
+    nv = 220
+    for gy in range(15):
+        for gx in range(20):
+            clat = 24.0 + (gy + 0.5) / 15.0
+            clon = -82.0 + (gx + 0.5) / 20.0
+            ring = [(clat + 0.015 * math.sin(2 * math.pi * k / nv),
+                     clon + 0.015 * math.cos(2 * math.pi * k / nv))
+                    for k in range(nv)]
+            if bw.ring_signed_area(ring) < 0:
+                ring.reverse()      # holes must be CCW (positive area)
+            holes.append(ring)
+            centers.append((clat, clon))
+    return outer, holes, centers
+
+
+class TestDenseCellUint32:
+    """Residual B of #44: a row whose total vertex count exceeds the
+    uint16 index range must keep its holes via uint32 triangle/ring
+    indices — not silently drop them all. The dtype is implied by the
+    row's vertex count on both the build and the read side."""
+
+    @pytest.fixture(scope="class")
+    def dense_db(self, tmp_path_factory):
+        tmp = tmp_path_factory.mktemp("dense_water")
+        path = tmp / "water.sqlite"
+        con = sqlite3.connect(str(path))
+        con.executescript(bw.SCHEMA)
+        outer, holes, centers = _dense_multipolygon()
+        assert bw.insert_polygon(con, "ocean", None, outer,
+                                 max_vertices=None, holes=holes)
+        con.commit()
+        con.close()
+        return path, centers
+
+    def test_row_keeps_all_holes_past_uint16(self, dense_db):
+        path, centers = dense_db
+        rows = _fetch_rows(path)
+        assert len(rows) == 1                    # holes never become rows
+        verts, tris, rings = _decode(rows[0])
+        assert len(verts) == 66004               # nothing dropped
+        assert len(verts) > 65535                # the case uint16 cannot hold
+        assert rings is not None
+        assert len(rings) == 1 + len(centers)    # outer + every hole
+        assert rings[-1] == len(verts)
+
+    def test_blobs_are_uint32_and_indices_valid(self, dense_db):
+        path, _ = dense_db
+        row = _fetch_rows(path)[0]
+        verts, tris, rings = _decode(row)
+        # 4-byte little-endian indices on disk, decoded 1:1.
+        assert len(row["triangles"]) == len(tris) * 4
+        assert len(row["rings"]) == len(rings) * 4
+        assert len(tris) % 3 == 0
+        assert max(tris) < len(verts)
+        # Vertices past the uint16 range are actually referenced —
+        # proof the fill really spans the whole ring set.
+        assert max(tris) > 65535
+        assert max(rings) > 65535
+
+    def test_no_hole_interior_covered_full_sweep(self, dense_db):
+        # The DoD sweep: every hole interior point (in-ring by
+        # even-odd) must be clear of the row's fill triangles, and
+        # water between the islands must still be filled.
+        path, centers = dense_db
+        verts, tris, rings = _decode(_fetch_rows(path)[0])
+        r2 = 0.015 / 2.0
+        island_pts = []
+        for clat, clon in centers:
+            island_pts.extend([(clat, clon),
+                               (clat + r2, clon), (clat - r2, clon),
+                               (clat, clon + r2), (clat, clon - r2)])
+        covered = _covered_points_mask(island_pts, verts, tris)
+        assert not covered.any(), (
+            f"{int(covered.sum())}/{len(island_pts)} island interior "
+            "points covered by water fill")
+        water_pts = [(24.0 + gy / 15.0, -82.0 + gx / 20.0)
+                     for gy, gx in ((1, 1), (7, 10), (14, 19),
+                                    (3, 15), (11, 4))]
+        assert _covered_points_mask(water_pts, verts, tris).all()
+
+    def test_waterdb_reads_dense_row_intact(self, dense_db):
+        from pyefis.instruments.ai.water_db import WaterDB
+        path, centers = dense_db
+        db = WaterDB(path, max_vertices=32)
+        assert db.ready is True
+        polys = list(db.polygons_in_range(24.5, -81.5, 30.0))
+        assert len(polys) == 1
+        poly = polys[0]
+        assert len(poly.vertices) == 66004       # never re-decimated
+        assert poly.rings is not None
+        assert len(poly.rings) == 1 + len(centers)
+        assert poly.triangles is not None
+        assert max(poly.triangles) < len(poly.vertices)
+        # Spot-check through the reader's own decode: island dry,
+        # surrounding water wet.
+        clat, clon = centers[0]
+        mask = _covered_points_mask([(clat, clon), (24.0 + 1 / 15.0,
+                                                    -82.0 + 1 / 20.0)],
+                                    poly.vertices, poly.triangles)
+        assert not mask[0]
+        assert mask[1]

--- a/tests/tools/test_build_water_db.py
+++ b/tests/tools/test_build_water_db.py
@@ -1,0 +1,256 @@
+#  SPDX-License-Identifier: GPL-2.0-or-later
+"""Tests for tools/build_water_db.py -- issue #44 island holes.
+
+An island is an interior (hole) ring of a water multipolygon. The old
+ingest emitted EVERY ring as its own filled polygon and tessellated
+single-ring only, so an island was painted as water twice over: the
+outer ring's fill covered it, and its own coastline became a filled
+ocean polygon (KEYW / Florida Keys, issue #44). These tests prove the
+builder now preserves ring topology: winding classification, hole
+grouping, hole-aware tessellation (an interior-ring point is NOT
+covered by the stored triangles; a surrounding-water point IS), and
+that a hole ring is never emitted as its own row.
+
+Plain pytest + tmp_path. mapbox_earcut is a build-time-only dep (the
+``watertools`` extra); the whole module skips without it.
+"""
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mapbox_earcut",
+                    reason="build-time tessellation dependency")
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(
+        name, _ROOT / "tools" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+bw = _load("build_water_db")
+
+
+# Synthetic island-in-water multipolygon around the Florida Keys.
+# Shapefile winding convention in (x=lon, y=lat): outer ring clockwise
+# (negative shoelace signed area), hole ring counter-clockwise
+# (positive). The hole is the island.
+OUTER_CW = [(24.0, -82.5), (25.0, -82.5), (25.0, -81.0), (24.0, -81.0)]
+HOLE_CCW = [(24.5, -81.8), (24.5, -81.7), (24.6, -81.7), (24.6, -81.8)]
+ISLAND_PT = (24.55, -81.75)     # interior of the hole -- must be LAND
+WATER_PT = (24.2, -82.0)        # inside outer, outside hole -- water
+
+
+def _open_db(tmp_path):
+    path = tmp_path / "water.sqlite"
+    con = sqlite3.connect(str(path))
+    con.executescript(bw.SCHEMA)
+    return path, con
+
+
+def _fetch_rows(path):
+    con = sqlite3.connect(str(path))
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT kind, vertices, triangles, rings "
+        "FROM water_polygons").fetchall()
+    con.close()
+    return rows
+
+
+def _decode(row):
+    from pyefis.instruments.ai.water_db import (
+        _decode_rings, _decode_triangles, _decode_vertices)
+    return (_decode_vertices(row["vertices"]),
+            _decode_triangles(row["triangles"]),
+            _decode_rings(row["rings"]))
+
+
+def _covered_by_triangles(lat, lon, vertices, triangles):
+    """True when (lat, lon) lies inside any stored fill triangle --
+    the exact question the GPU renderer answers, since it draws the
+    pre-tessellated triangles and nothing else."""
+    for t in range(0, len(triangles), 3):
+        (y1, x1) = vertices[triangles[t]]
+        (y2, x2) = vertices[triangles[t + 1]]
+        (y3, x3) = vertices[triangles[t + 2]]
+        d1 = (lon - x2) * (y1 - y2) - (x1 - x2) * (lat - y2)
+        d2 = (lon - x3) * (y2 - y3) - (x2 - x3) * (lat - y3)
+        d3 = (lon - x1) * (y3 - y1) - (x3 - x1) * (lat - y1)
+        neg = (d1 < 0) or (d2 < 0) or (d3 < 0)
+        pos = (d1 > 0) or (d2 > 0) or (d3 > 0)
+        if not (neg and pos):
+            return True
+    return False
+
+
+class TestRingClassification:
+    def test_shapefile_winding_signs(self):
+        # Outer = CW in (lon, lat) = negative signed area; hole = CCW
+        # = positive. This is the discriminator the whole fix rests on.
+        assert bw.ring_signed_area(OUTER_CW) < 0
+        assert bw.ring_signed_area(HOLE_CCW) > 0
+
+    def test_hole_grouped_under_containing_outer(self):
+        groups, orphans = bw.group_rings([OUTER_CW, HOLE_CCW])
+        assert orphans == 0
+        assert len(groups) == 1
+        outer, holes = groups[0]
+        assert outer == OUTER_CW
+        assert holes == [HOLE_CCW]
+
+    def test_orphan_hole_is_dropped_not_filled(self):
+        # A hole outside every outer must vanish -- emitting it filled
+        # is exactly the #44 bug.
+        far_hole = [(30.5, -70.8), (30.5, -70.7),
+                    (30.6, -70.7), (30.6, -70.8)]
+        groups, orphans = bw.group_rings([OUTER_CW, far_hole])
+        assert orphans == 1
+        assert groups == [(OUTER_CW, [])]
+
+    def test_single_ring_is_outer_regardless_of_winding(self):
+        # Natural Earth lakes / the text format don't guarantee
+        # shapefile winding; a lone ring always fills.
+        groups, orphans = bw.group_rings([HOLE_CCW])
+        assert orphans == 0
+        assert groups == [(HOLE_CCW, [])]
+
+    def test_all_ccw_shape_falls_back_to_fill_everything(self):
+        # Reversed-winding source: no CW ring at all. Fill every ring
+        # (the pre-#44 behavior) rather than dropping the shape.
+        a = [(24.5, -81.8), (24.5, -81.7), (24.6, -81.7), (24.6, -81.8)]
+        b = [(25.5, -80.8), (25.5, -80.7), (25.6, -80.7), (25.6, -80.8)]
+        groups, orphans = bw.group_rings([a, b])
+        assert orphans == 0
+        assert sorted(map(id, (g[0] for g in groups))) == \
+            sorted(map(id, [a, b]))
+        assert all(h == [] for _, h in groups)
+
+    def test_nested_hole_goes_to_smallest_outer(self):
+        # Lake (outer) on an island (hole) in the sea (outer): the
+        # island's pond-hole belongs to the small lake outer, not the
+        # ocean outer that also contains it.
+        lake_cw = [(24.52, -81.78), (24.58, -81.78),
+                   (24.58, -81.72), (24.52, -81.72)]
+        pond_hole = [(24.54, -81.76), (24.54, -81.74),
+                     (24.56, -81.74), (24.56, -81.76)]
+        groups, orphans = bw.group_rings([OUTER_CW, lake_cw, pond_hole])
+        assert orphans == 0
+        by_outer = {id(o): h for o, h in groups}
+        assert by_outer[id(lake_cw)] == [pond_hole]
+        assert by_outer[id(OUTER_CW)] == []
+
+
+class TestIslandNotFilled:
+    """The #44 acceptance test: after the build, the island interior
+    is NOT covered by the stored water fill and the surrounding ring
+    IS -- judged on the tessellated triangles, which are exactly what
+    the GPU renderer draws."""
+
+    def test_hole_excluded_from_fill_and_not_its_own_row(self, tmp_path):
+        path, con = _open_db(tmp_path)
+        assert bw.insert_polygon(con, "ocean", None, OUTER_CW,
+                                 max_vertices=32, holes=[HOLE_CCW])
+        con.commit()
+        con.close()
+
+        rows = _fetch_rows(path)
+        # Mechanism 2 of #44: the hole must NOT appear as its own
+        # filled polygon row.
+        assert len(rows) == 1
+        verts, tris, rings = _decode(rows[0])
+        assert rings is not None and len(rings) == 2
+        assert tris is not None
+        # Mechanism 1 of #44: the outer fill must exclude the hole.
+        assert not _covered_by_triangles(*ISLAND_PT, verts, tris)
+        assert _covered_by_triangles(*WATER_PT, verts, tris)
+
+    def test_single_ring_row_stores_no_rings_blob(self, tmp_path):
+        path, con = _open_db(tmp_path)
+        assert bw.insert_polygon(con, "ocean", None, OUTER_CW,
+                                 max_vertices=32)
+        con.commit()
+        con.close()
+        rows = _fetch_rows(path)
+        assert len(rows) == 1
+        verts, tris, rings = _decode(rows[0])
+        assert rings is None
+        assert _covered_by_triangles(*ISLAND_PT, verts, tris)  # no hole
+
+    def test_per_ring_decimation_keeps_topology(self, tmp_path):
+        # A many-vertex outer ring decimates to the cap; the hole ring
+        # survives as a distinct ring and its interior stays dry.
+        import math
+        n = 240
+        dense_outer = [(24.5 + 0.5 * math.sin(2 * math.pi * k / n),
+                        -81.75 + 0.75 * math.cos(2 * math.pi * k / n))
+                       for k in range(n)]
+        if bw.ring_signed_area(dense_outer) > 0:
+            dense_outer.reverse()
+        path, con = _open_db(tmp_path)
+        assert bw.insert_polygon(con, "ocean", None, dense_outer,
+                                 max_vertices=32, holes=[HOLE_CCW])
+        con.commit()
+        con.close()
+        verts, tris, rings = _decode(_fetch_rows(path)[0])
+        assert rings is not None and len(rings) == 2
+        assert rings[0] <= 32                     # outer capped per-ring
+        assert rings[1] == len(verts)
+        assert not _covered_by_triangles(*ISLAND_PT, verts, tris)
+        assert _covered_by_triangles(*WATER_PT, verts, tris)
+
+
+class TestShapefileImport:
+    def test_multi_ring_shapefile_end_to_end(self, tmp_path):
+        shapefile = pytest.importorskip(
+            "shapefile", reason="pyshp is a build-time-only dependency")
+        shp = tmp_path / "ocean"
+        w = shapefile.Writer(str(shp), shapeType=shapefile.POLYGON)
+        w.field("id", "N")
+        # pyshp wants (lon, lat) parts; winding as stored above.
+        w.poly([[(lon, lat) for lat, lon in OUTER_CW + OUTER_CW[:1]],
+                [(lon, lat) for lat, lon in HOLE_CCW + HOLE_CCW[:1]]])
+        w.record(1)
+        w.close()
+
+        path, con = _open_db(tmp_path)
+        n = bw.import_shapefile(con, str(shp) + ".shp", "ocean", 32)
+        con.commit()
+        con.close()
+        assert n == 1
+        rows = _fetch_rows(path)
+        assert len(rows) == 1                    # hole is not its own row
+        verts, tris, rings = _decode(rows[0])
+        assert rings is not None
+        assert not _covered_by_triangles(*ISLAND_PT, verts, tris)
+        assert _covered_by_triangles(*WATER_PT, verts, tris)
+
+    def test_waterdb_reads_multi_ring_row_intact(self, tmp_path):
+        from pyefis.instruments.ai.water_db import WaterDB
+        path, con = _open_db(tmp_path)
+        assert bw.insert_polygon(con, "ocean", None, OUTER_CW,
+                                 max_vertices=32, holes=[HOLE_CCW])
+        con.commit()
+        con.close()
+
+        # max_vertices below the 8 stored vertices: a legacy single-ring
+        # row would be re-decimated; a multi-ring row must never be.
+        db = WaterDB(path, max_vertices=6)
+        assert db.ready is True
+        polys = list(db.polygons_in_range(24.55, -81.75, 30.0))
+        assert len(polys) == 1
+        poly = polys[0]
+        assert poly.rings == [4, 8]
+        assert len(poly.vertices) == 8           # never re-decimated
+        assert poly.outer_vertices == poly.vertices[:4]
+        assert poly.triangles is not None
+        assert max(poly.triangles) < len(poly.vertices)
+        assert not _covered_by_triangles(*ISLAND_PT, poly.vertices,
+                                         poly.triangles)

--- a/tools/build_water_db.py
+++ b/tools/build_water_db.py
@@ -233,6 +233,127 @@ def _point_in_ring(lat, lon, ring):
     return inside
 
 
+def _ring_interior_points(ring, max_points=3):
+    """Up to ``max_points`` points strictly inside a (lat, lon) ring,
+    found by even-odd scanline: cut the ring at a constant-lat line,
+    sort the edge crossings, take midpoints of the odd (inside) spans.
+    Works for concave and even self-intersecting rings — 'inside' is
+    exactly the even-odd sense the renderer fills with."""
+    lats = [v[0] for v in ring]
+    lo, hi = min(lats), max(lats)
+    if hi <= lo:
+        return []
+    pts = []
+    n = len(ring)
+    for frac in (0.5, 0.3, 0.7):
+        lat = lo + (hi - lo) * frac
+        xs = []
+        for i in range(n):
+            la1, lo1 = ring[i]
+            la2, lo2 = ring[(i + 1) % n]
+            if (la1 > lat) != (la2 > lat):
+                xs.append(lo1 + (lat - la1) / (la2 - la1) * (lo2 - lo1))
+        xs.sort()
+        for k in range(0, len(xs) - 1, 2):
+            if xs[k + 1] > xs[k]:
+                pts.append((lat, 0.5 * (xs[k] + xs[k + 1])))
+                if len(pts) >= max_points:
+                    return pts
+    return pts
+
+
+def _triangle_cover_tester(vertices, tri_idx):
+    """Build a covered(lat, lon) -> bool closure over a tessellation.
+    Triangles are binned into latitude strips so each query tests only
+    the local candidates — a dense island cell carries 10^5 triangles
+    and the verification sweep visits thousands of points."""
+    v = np.asarray(vertices, dtype=np.float64)
+    t = np.asarray(tri_idx, dtype=np.int64).reshape(-1, 3)
+    if t.size == 0:
+        return lambda lat, lon: False
+    a, b, c = v[t[:, 0]], v[t[:, 1]], v[t[:, 2]]
+    lat_min = np.minimum(np.minimum(a[:, 0], b[:, 0]), c[:, 0])
+    lat_max = np.maximum(np.maximum(a[:, 0], b[:, 0]), c[:, 0])
+    lon_min = np.minimum(np.minimum(a[:, 1], b[:, 1]), c[:, 1])
+    lon_max = np.maximum(np.maximum(a[:, 1], b[:, 1]), c[:, 1])
+    strips = min(64, max(1, len(t) // 64))
+    lo = float(lat_min.min())
+    span = max(float(lat_max.max()) - lo, 1e-12)
+    s_lo = np.clip(((lat_min - lo) / span * strips).astype(int),
+                   0, strips - 1)
+    s_hi = np.clip(((lat_max - lo) / span * strips).astype(int),
+                   0, strips - 1)
+    bins = [[] for _ in range(strips)]
+    for i in range(len(t)):
+        for s in range(s_lo[i], s_hi[i] + 1):
+            bins[s].append(i)
+    bins = [np.asarray(bn, dtype=np.int64) for bn in bins]
+
+    def covered(lat, lon):
+        s = int(np.clip((lat - lo) / span * strips, 0, strips - 1))
+        cand = bins[s]
+        if cand.size == 0:
+            return False
+        m = ((lat_min[cand] <= lat) & (lat_max[cand] >= lat)
+             & (lon_min[cand] <= lon) & (lon_max[cand] >= lon))
+        cand = cand[m]
+        if cand.size == 0:
+            return False
+        aa, bb, cc = a[cand], b[cand], c[cand]
+        d1 = ((lon - bb[:, 1]) * (aa[:, 0] - bb[:, 0])
+              - (aa[:, 1] - bb[:, 1]) * (lat - bb[:, 0]))
+        d2 = ((lon - cc[:, 1]) * (bb[:, 0] - cc[:, 0])
+              - (bb[:, 1] - cc[:, 1]) * (lat - cc[:, 0]))
+        d3 = ((lon - aa[:, 1]) * (cc[:, 0] - aa[:, 0])
+              - (cc[:, 1] - aa[:, 1]) * (lat - aa[:, 0]))
+        neg = (d1 < 0) | (d2 < 0) | (d3 < 0)
+        pos = (d1 > 0) | (d2 > 0) | (d3 > 0)
+        return bool((~(neg & pos)).any())
+
+    return covered
+
+
+def _covered_hole_indices(all_verts, ring_ends, tri_idx):
+    """Indices (into the hole list) of hole rings whose interior is
+    covered by the row's fill triangles — the residual-A defect class
+    of #44: decimation can hand earcut a self-intersecting or outer-
+    crossing hole, and earcut then fills it instead of subtracting
+    it. Judged on the STORED rings and triangles, i.e. exactly what
+    the renderer will draw."""
+    if len(ring_ends) <= 1:
+        return []
+    covered = _triangle_cover_tester(all_verts, tri_idx)
+    bad = []
+    for k in range(1, len(ring_ends)):
+        ring = all_verts[ring_ends[k - 1]:ring_ends[k]]
+        if any(covered(lat, lon)
+               for lat, lon in _ring_interior_points(ring)):
+            bad.append(k - 1)
+    return bad
+
+
+def _strip_hole_triangles(all_verts, ring_ends, tri_idx):
+    """Last-resort repair when even the raw source rings tessellate
+    with covered holes: drop fill triangles whose centroid lies inside
+    any hole ring (even-odd). Biased toward land — for an EFIS,
+    painting an island as water is the dangerous direction (#44)."""
+    v = np.asarray(all_verts, dtype=np.float64)
+    t = np.asarray(tri_idx, dtype=np.int64).reshape(-1, 3)
+    clat = (v[t[:, 0], 0] + v[t[:, 1], 0] + v[t[:, 2], 0]) / 3.0
+    clon = (v[t[:, 0], 1] + v[t[:, 1], 1] + v[t[:, 2], 1]) / 3.0
+    keep = np.ones(len(t), dtype=bool)
+    for k in range(1, len(ring_ends)):
+        ring = all_verts[ring_ends[k - 1]:ring_ends[k]]
+        rlats = [p[0] for p in ring]
+        rlons = [p[1] for p in ring]
+        m = ((clat >= min(rlats)) & (clat <= max(rlats))
+             & (clon >= min(rlons)) & (clon <= max(rlons)) & keep)
+        for i in np.nonzero(m)[0]:
+            if _point_in_ring(clat[i], clon[i], ring):
+                keep[i] = False
+    return t[keep].reshape(-1)
+
+
 def group_rings(rings):
     """Group a shape's rings into (outer, [holes]) pairs by winding +
     containment, so holes (islands) can be subtracted from their outer
@@ -285,56 +406,111 @@ def group_rings(rings):
     return list(groups.values()), orphans
 
 
+# Escalation bound for the per-ring decimation cap when hole
+# verification fails: the cap doubles up to this value, then the raw
+# source rings are used. Bounded so a pathological shape cannot loop.
+_MAX_ESCALATED_CAP = 512
+
+
 def insert_polygon(con, kind, elev_ft, vertices, max_vertices=None,
-                   holes=None):
+                   holes=None, stats=None):
     """Insert one water polygon: ``vertices`` is the OUTER ring,
     ``holes`` an optional list of interior (island) rings subtracted
-    from the fill. Returns False if the outer ring is degenerate."""
+    from the fill. Returns False if the outer ring is degenerate.
+
+    Multi-ring rows are VERIFIED after tessellation: every hole ring
+    must keep its interior clear of the row's fill triangles. The
+    per-ring decimation runs before earcut sees the rings, and an
+    aggressively simplified ring can self-intersect or cross its outer
+    ring — earcut then fills the hole instead of subtracting it
+    (oracle-gate residual A of #44: 54/770 hole interiors covered in
+    a Keys probe build). On a failed verification the decimation cap
+    escalates (doubling up to _MAX_ESCALATED_CAP, then the raw source
+    rings); if the raw rings still fail, fill triangles whose centroid
+    lands in a hole are stripped as a last resort — biased toward
+    land, since painting an island as water is the dangerous direction
+    for an EFIS. ``stats`` (a dict, optional) accumulates 'escalated'
+    / 'stripped' / 'unresolved' row counts for the caller's summary."""
     if len(vertices) < 3:
         return False
-    # Decimate at build time so the BLOBs stored on disk are small.
-    # Reading a 50-100 KB BLOB per polygon at query time was the
-    # dominant cost in the perf log; with a 32-vertex cap each BLOB
-    # is ~512 bytes and the query is bound by index scanning rather
-    # than disk I/O. Multi-ring: the cap applies PER RING (outer and
-    # each hole) — the reader skips its own decimation for multi-ring
-    # rows, so the build-time cap is the only bound.
-    vertices = _decimate(vertices, max_vertices)
-    holes = [h for h in (_decimate(h, max_vertices) for h in (holes or []))
-             if len(h) >= 3]
+    src_holes = [h for h in (holes or []) if len(h) >= 3]
+    cap = max_vertices
+    escalated = stripped = unresolved = False
+    while True:
+        # Decimate at build time so the BLOBs stored on disk are small.
+        # Reading a 50-100 KB BLOB per polygon at query time was the
+        # dominant cost in the perf log; with a 32-vertex cap each BLOB
+        # is ~512 bytes and the query is bound by index scanning rather
+        # than disk I/O. Multi-ring: the cap applies PER RING (outer and
+        # each hole) — the reader skips its own decimation for multi-ring
+        # rows, so the build-time cap is the only bound.
+        out_ring = _decimate(vertices, cap)
+        dec_holes = [h for h in (_decimate(h, cap) for h in src_holes)
+                     if len(h) >= 3]
+        all_verts = list(out_ring)
+        ring_ends = [len(out_ring)]
+        for h in dec_holes:
+            all_verts.extend(h)
+            ring_ends.append(len(all_verts))
+        # Pre-tessellate. The renderer reads these indices directly
+        # into a GL element-array buffer at draw time — keeps per-frame
+        # Python work down to a buffer upload + glDrawElements call.
+        # Hole-aware: earcut subtracts the hole rings so islands are
+        # not filled (#44). Rows past 65535 vertices store uint32
+        # indices instead of losing their holes (the old drop-the-holes
+        # fallback re-created #44 in exactly the densest island cells).
+        tri_idx = tessellate_polygon(all_verts,
+                                     ring_ends if dec_holes else None)
+        if not src_holes:
+            break               # single-ring rows: nothing to verify
+        if (tri_idx is not None
+                and not _covered_hole_indices(all_verts, ring_ends,
+                                              tri_idx)):
+            break               # verified: every hole interior is dry
+        if cap is not None:
+            cap = cap * 2 if cap * 2 <= _MAX_ESCALATED_CAP else None
+            escalated = True
+            continue
+        # Raw source rings and the fill still covers a hole (or earcut
+        # refused the ring set outright).
+        if tri_idx is None:
+            # Store the outer ring alone rather than a multi-ring
+            # vertex blob without triangles, which would draw garbage
+            # through the renderer's fan fallback.
+            all_verts = list(out_ring)
+            ring_ends = [len(out_ring)]
+            dec_holes = []
+            tri_idx = tessellate_polygon(all_verts)
+            unresolved = True
+        else:
+            tri_idx = _strip_hole_triangles(all_verts, ring_ends,
+                                            tri_idx)
+            stripped = True
+            if _covered_hole_indices(all_verts, ring_ends, tri_idx):
+                unresolved = True
+        break
+    if stats is not None and src_holes:
+        for flag, key in ((escalated, "escalated"),
+                          (stripped, "stripped"),
+                          (unresolved, "unresolved")):
+            if flag:
+                stats[key] = stats.get(key, 0) + 1
+    if unresolved:
+        print("  WARNING: hole verification unresolved for a "
+              f"{len(src_holes)}-hole polygon near "
+              f"({vertices[0][0]:.3f}, {vertices[0][1]:.3f}) — "
+              "some island interior may render as water",
+              file=sys.stderr)
     # The bbox is the outer ring's — holes lie inside it by definition.
-    lats = [v[0] for v in vertices]
-    lons = [v[1] for v in vertices]
+    lats = [v[0] for v in out_ring]
+    lons = [v[1] for v in out_ring]
     min_lat, max_lat = min(lats), max(lats)
     min_lon, max_lon = min(lons), max(lons)
-    all_verts = list(vertices)
-    ring_ends = [len(vertices)]
-    for h in holes:
-        all_verts.extend(h)
-        ring_ends.append(len(all_verts))
-    # Pre-tessellate. The renderer reads these indices directly into a
-    # GL element-array buffer at draw time — keeps per-frame Python
-    # work down to a buffer upload + glDrawElements call. Hole-aware:
-    # earcut subtracts the hole rings so islands are not filled (#44).
-    # Rows past 65535 vertices store uint32 indices instead of losing
-    # their holes (the old drop-the-holes fallback re-created #44 in
-    # exactly the densest island cells).
-    tri_idx = tessellate_polygon(all_verts,
-                                 ring_ends if holes else None)
-    if tri_idx is None and holes:
-        # Hole-aware tessellation failed — fall back to the outer ring
-        # alone so the stored row stays consistent (a multi-ring vertex
-        # blob without triangles would draw garbage through the
-        # renderer's fan fallback).
-        all_verts = list(vertices)
-        ring_ends = [len(vertices)]
-        holes = []
-        tri_idx = tessellate_polygon(all_verts)
     idx_dtype = _index_dtype(len(all_verts))
     tri_blob = (np.asarray(tri_idx, dtype=idx_dtype).tobytes()
                 if tri_idx is not None else None)
     rings_blob = (np.asarray(ring_ends, dtype=idx_dtype).tobytes()
-                  if holes else None)
+                  if dec_holes else None)
     cur = con.execute(
         "INSERT INTO water_polygons "
         "(min_lat, max_lat, min_lon, max_lon, kind, elev_ft, "
@@ -398,6 +574,7 @@ def import_shapefile(con, path, kind, max_vertices, elev_ft=None,
     fc_dropped = 0
     holes_kept = 0
     orphan_holes = 0
+    hole_stats = {}
     records = sf.iterShapeRecords() if use_fclass else (
         (shape, None) for shape in sf.shapes())
     for item in records:
@@ -422,7 +599,7 @@ def import_shapefile(con, path, kind, max_vertices, elev_ft=None,
                 dropped += 1
                 continue
             if insert_polygon(con, kind, elev_ft, outer, max_vertices,
-                              holes=holes):
+                              holes=holes, stats=hole_stats):
                 n += 1
                 holes_kept += len(holes)
     notes = []
@@ -434,8 +611,14 @@ def import_shapefile(con, path, kind, max_vertices, elev_ft=None,
         notes.append(f"{orphan_holes} orphan hole(s)")
     extra = f" ({', '.join(notes)} dropped)" if notes else ""
     holes_note = f" (+{holes_kept} island hole(s))" if holes_kept else ""
+    verify_bits = [f"{hole_stats[k]} {label}" for k, label in
+                   (("escalated", "row(s) escalated past the cap"),
+                    ("stripped", "row(s) strip-repaired"),
+                    ("unresolved", "row(s) UNRESOLVED"))
+                   if hole_stats.get(k)]
+    vnote = f" [hole verify: {', '.join(verify_bits)}]" if verify_bits else ""
     print(f"  {Path(path).name}: imported {n} polygon(s) as "
-          f"kind={kind}{holes_note}{extra}")
+          f"kind={kind}{holes_note}{extra}{vnote}")
     return n
 
 

--- a/tools/build_water_db.py
+++ b/tools/build_water_db.py
@@ -48,31 +48,35 @@ import mapbox_earcut as _earcut
 import numpy as np
 
 
-def tessellate_polygon(vertices):
-    """Triangulate a single-ring polygon via earcut. Returns a numpy
-    array of uint16 indices (3 per triangle) into ``vertices``, or
-    None if the input is degenerate / fails tessellation.
+def tessellate_polygon(vertices, ring_ends=None):
+    """Triangulate a polygon via earcut. Returns a numpy array of
+    uint16 indices (3 per triangle) into ``vertices``, or None if the
+    input is degenerate / fails tessellation.
 
     ``vertices`` is a list of (lat, lon) tuples — earcut sees them
     as generic 2D points, so lat/lon vs xy doesn't matter at this
-    stage. Each output index is in [0, len(vertices))."""
+    stage. Each output index is in [0, len(vertices)).
+
+    ``ring_ends`` is the earcut ring-end-index list for a multi-ring
+    (outer + holes) polygon: ``vertices`` holds the outer ring followed
+    by each hole ring, and ``ring_ends[k]`` is the end offset of ring
+    k. earcut then subtracts the holes from the fill (#44 — island
+    holes must not triangulate as water). None means single ring."""
     if len(vertices) < 3:
         return None
-    # earcut wants a flat float64 Nx2 array and a ring-end-index list.
-    # Single ring => one element pointing at the end of the vertex
-    # array. Multi-ring (outer + holes) support comes later if we
-    # need it; current OSM ingest collapses multi-rings into
-    # single-ring polygons.
     pts = np.asarray(vertices, dtype=np.float64)
-    rings = np.asarray([len(pts)], dtype=np.uint32)
+    if ring_ends is None:
+        ring_ends = [len(pts)]
+    rings = np.asarray(ring_ends, dtype=np.uint32)
     try:
         idx = _earcut.triangulate_float64(pts, rings)
     except Exception:
         return None
     if idx.size == 0 or (idx.size % 3) != 0:
         return None
-    # uint16 caps us at 65535 vertices per polygon — every polygon we
-    # store is decimated to <=32 vertices so this is comfortably safe.
+    # uint16 caps us at 65535 vertices per polygon — rings are
+    # decimated to <=32 vertices each at build time and insert_polygon
+    # refuses multi-ring rows past the uint16 range, so this is safe.
     return idx.astype(np.uint16)
 
 
@@ -91,7 +95,14 @@ CREATE TABLE IF NOT EXISTS water_polygons (
     -- only when tessellation failed at build time (logged as a
     -- warning). The GPU water renderer uploads these directly to a
     -- GL element-array buffer with one draw call per polygon.
-    triangles BLOB
+    triangles BLOB,
+    -- Ring topology for multi-ring (outer + hole) polygons, packed as
+    -- little-endian uint16 ring END offsets into ``vertices`` (earcut
+    -- convention: outer ring first, then each hole ring). NULL for
+    -- plain single-ring polygons — the overwhelming majority. When
+    -- present, ``triangles`` was tessellated hole-aware, so island
+    -- holes are excluded from the fill (#44).
+    rings     BLOB
 );
 CREATE INDEX IF NOT EXISTS idx_bbox
     ON water_polygons(min_lat, max_lat, min_lon, max_lon);
@@ -173,31 +184,151 @@ def _decimate(vertices, max_vertices):
             for k in range(max_vertices)]
 
 
-def insert_polygon(con, kind, elev_ft, vertices, max_vertices=None):
+def ring_signed_area(vertices):
+    """Shoelace signed area of a (lat, lon) ring in degrees^2, computed
+    in (x=lon, y=lat) plane coordinates. Shapefile winding convention:
+    OUTER rings are clockwise in (x, y) => NEGATIVE signed area; HOLE
+    rings (islands) are counter-clockwise => POSITIVE. The winding
+    survives our ingest, so it is the outer-vs-hole discriminator."""
+    n = len(vertices)
+    if n < 3:
+        return 0.0
+    s = 0.0
+    for i in range(n):
+        lat1, lon1 = vertices[i]
+        lat2, lon2 = vertices[(i + 1) % n]
+        s += lon1 * lat2 - lon2 * lat1
+    return s / 2.0
+
+
+def _point_in_ring(lat, lon, ring):
+    """Even-odd ray-cast point-in-polygon on a (lat, lon) ring."""
+    inside = False
+    n = len(ring)
+    for i in range(n):
+        la1, lo1 = ring[i]
+        la2, lo2 = ring[(i + 1) % n]
+        if (la1 > lat) != (la2 > lat):
+            x = lo1 + (lat - la1) / (la2 - la1) * (lo2 - lo1)
+            if x > lon:
+                inside = not inside
+    return inside
+
+
+def group_rings(rings):
+    """Group a shape's rings into (outer, [holes]) pairs by winding +
+    containment, so holes (islands) can be subtracted from their outer
+    ring's fill instead of being emitted as filled water (#44).
+
+    - A single-ring shape is always an outer, regardless of winding —
+      preserves every existing single-ring source (Natural Earth lakes,
+      the text format) that may not follow shapefile winding.
+    - Multi-ring: negative signed area (CW) = outer, positive = hole.
+      Each hole is assigned to the smallest outer whose bbox and even-odd
+      interior contain the hole's first vertex — smallest-first handles
+      nesting (lake on an island in a lake).
+    - Anomalies fall back to the pre-#44 fill-everything behavior:
+      a shape with no CW ring treats all rings as outers (reversed-
+      winding source); a hole with no containing outer is DROPPED
+      (never filled — filling holes is exactly the #44 bug).
+
+    Returns (groups, orphan_holes) where groups is a list of
+    (outer_ring, [hole_rings]) and orphan_holes counts dropped holes."""
+    rings = [r for r in rings if len(r) >= 3]
+    if not rings:
+        return [], 0
+    if len(rings) == 1:
+        return [(rings[0], [])], 0
+    areas = [ring_signed_area(r) for r in rings]
+    outers = [(r, abs(a)) for r, a in zip(rings, areas) if a < 0]
+    holes = [r for r, a in zip(rings, areas) if a >= 0]
+    if not outers:
+        # Reversed-winding (or degenerate) source — fill every ring,
+        # exactly what the pre-#44 ingest did.
+        return [(r, []) for r in rings], 0
+    outers.sort(key=lambda t: t[1])          # smallest first
+    groups = {id(r): (r, []) for r, _ in outers}
+    orphans = 0
+    for hole in holes:
+        hlat, hlon = hole[0]
+        placed = False
+        for outer, _ in outers:
+            lats = [v[0] for v in outer]
+            lons = [v[1] for v in outer]
+            if not (min(lats) <= hlat <= max(lats)
+                    and min(lons) <= hlon <= max(lons)):
+                continue
+            if _point_in_ring(hlat, hlon, outer):
+                groups[id(outer)][1].append(hole)
+                placed = True
+                break
+        if not placed:
+            orphans += 1
+    return list(groups.values()), orphans
+
+
+def insert_polygon(con, kind, elev_ft, vertices, max_vertices=None,
+                   holes=None):
+    """Insert one water polygon: ``vertices`` is the OUTER ring,
+    ``holes`` an optional list of interior (island) rings subtracted
+    from the fill. Returns False if the outer ring is degenerate."""
     if len(vertices) < 3:
         return False
     # Decimate at build time so the BLOBs stored on disk are small.
     # Reading a 50-100 KB BLOB per polygon at query time was the
     # dominant cost in the perf log; with a 32-vertex cap each BLOB
     # is ~512 bytes and the query is bound by index scanning rather
-    # than disk I/O.
+    # than disk I/O. Multi-ring: the cap applies PER RING (outer and
+    # each hole) — the reader skips its own decimation for multi-ring
+    # rows, so the build-time cap is the only bound.
     vertices = _decimate(vertices, max_vertices)
+    holes = [h for h in (_decimate(h, max_vertices) for h in (holes or []))
+             if len(h) >= 3]
+    # The bbox is the outer ring's — holes lie inside it by definition.
     lats = [v[0] for v in vertices]
     lons = [v[1] for v in vertices]
     min_lat, max_lat = min(lats), max(lats)
     min_lon, max_lon = min(lons), max(lons)
+    all_verts = list(vertices)
+    ring_ends = [len(vertices)]
+    for h in holes:
+        all_verts.extend(h)
+        ring_ends.append(len(all_verts))
+    if len(all_verts) > 65535:
+        # uint16 triangle-index ceiling — drop the holes rather than
+        # store corrupt indices (only reachable with the vertex cap
+        # disabled on a pathological polygon).
+        print(f"  WARNING: {len(all_verts)} vertices exceeds the uint16 "
+              "index range; dropping holes for this polygon",
+              file=sys.stderr)
+        all_verts = list(vertices)
+        ring_ends = [len(vertices)]
+        holes = []
     # Pre-tessellate. The renderer reads these indices directly into a
     # GL element-array buffer at draw time — keeps per-frame Python
-    # work down to a buffer upload + glDrawElements call.
-    tri_idx = tessellate_polygon(vertices)
+    # work down to a buffer upload + glDrawElements call. Hole-aware:
+    # earcut subtracts the hole rings so islands are not filled (#44).
+    tri_idx = tessellate_polygon(all_verts,
+                                 ring_ends if holes else None)
+    if tri_idx is None and holes:
+        # Hole-aware tessellation failed — fall back to the outer ring
+        # alone so the stored row stays consistent (a multi-ring vertex
+        # blob without triangles would draw garbage through the
+        # renderer's fan fallback).
+        all_verts = list(vertices)
+        ring_ends = [len(vertices)]
+        holes = []
+        tri_idx = tessellate_polygon(all_verts)
     tri_blob = tri_idx.tobytes() if tri_idx is not None else None
+    rings_blob = (np.asarray(ring_ends, dtype=np.uint16).tobytes()
+                  if holes else None)
     cur = con.execute(
         "INSERT INTO water_polygons "
         "(min_lat, max_lat, min_lon, max_lon, kind, elev_ft, "
-        " vertices, triangles) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        " vertices, triangles, rings) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (min_lat, max_lat, min_lon, max_lon,
-         kind, elev_ft, encode_vertices(vertices), tri_blob))
+         kind, elev_ft, encode_vertices(all_verts), tri_blob, rings_blob))
     con.execute(
         "INSERT INTO water_rtree (id, min_lat, max_lat, min_lon, max_lon) "
         "VALUES (?, ?, ?, ?, ?)",
@@ -224,9 +355,14 @@ def ring_area_km2(vertices):
 
 def import_shapefile(con, path, kind, max_vertices, elev_ft=None,
                      min_area_km2=0.0, keep_fclass=None):
-    """Import every polygon (and every ring of every multi-polygon) from
-    a shapefile into the water_polygons table. Rings smaller than
-    ``min_area_km2`` are skipped (declutters tiny ponds; 0 disables).
+    """Import every polygon from a shapefile into the water_polygons
+    table. Multi-ring shapes are grouped by winding + containment
+    (``group_rings``): one row per OUTER ring, with its interior (hole)
+    rings stored alongside and subtracted from the tessellated fill —
+    a hole ring is never emitted as its own filled polygon (#44).
+    Outer rings smaller than ``min_area_km2`` are skipped (declutters
+    tiny ponds; 0 disables; holes are never size-filtered — dropping a
+    hole fills its island).
 
     ``keep_fclass`` (a set of OSM feature classes) keeps only those classes
     when the shapefile has an ``fclass`` field — used to keep still open water
@@ -247,6 +383,8 @@ def import_shapefile(con, path, kind, max_vertices, elev_ft=None,
     n = 0
     dropped = 0
     fc_dropped = 0
+    holes_kept = 0
+    orphan_holes = 0
     records = sf.iterShapeRecords() if use_fclass else (
         (shape, None) for shape in sf.shapes())
     for item in records:
@@ -256,24 +394,35 @@ def import_shapefile(con, path, kind, max_vertices, elev_ft=None,
             continue
         if not shape.points:
             continue
-        # shape.parts marks the start of each ring; iterate ring by ring.
+        # shape.parts marks the start of each ring; split ring by ring,
+        # then group outer rings with their holes by winding (#44).
         parts = list(shape.parts) + [len(shape.points)]
+        rings = []
         for k in range(len(parts) - 1):
             ring = shape.points[parts[k]:parts[k + 1]]
             # Shapefile stores (lon, lat); we want (lat, lon).
-            vertices = [(p[1], p[0]) for p in ring]
-            if min_area_km2 > 0 and ring_area_km2(vertices) < min_area_km2:
+            rings.append([(p[1], p[0]) for p in ring])
+        groups, orphans = group_rings(rings)
+        orphan_holes += orphans
+        for outer, holes in groups:
+            if min_area_km2 > 0 and ring_area_km2(outer) < min_area_km2:
                 dropped += 1
                 continue
-            if insert_polygon(con, kind, elev_ft, vertices, max_vertices):
+            if insert_polygon(con, kind, elev_ft, outer, max_vertices,
+                              holes=holes):
                 n += 1
+                holes_kept += len(holes)
     notes = []
     if dropped:
         notes.append(f"{dropped} below {min_area_km2} km^2")
     if fc_dropped:
         notes.append(f"{fc_dropped} off-class")
+    if orphan_holes:
+        notes.append(f"{orphan_holes} orphan hole(s)")
     extra = f" ({', '.join(notes)} dropped)" if notes else ""
-    print(f"  {Path(path).name}: imported {n} ring(s) as kind={kind}{extra}")
+    holes_note = f" (+{holes_kept} island hole(s))" if holes_kept else ""
+    print(f"  {Path(path).name}: imported {n} polygon(s) as "
+          f"kind={kind}{holes_note}{extra}")
     return n
 
 

--- a/tools/build_water_db.py
+++ b/tools/build_water_db.py
@@ -48,9 +48,19 @@ import mapbox_earcut as _earcut
 import numpy as np
 
 
+def _index_dtype(n_vertices):
+    """Dtype for the ``triangles`` and ``rings`` BLOBs of a row with
+    ``n_vertices`` total vertices. uint16 covers indices 0..65534 and
+    the final ring-end offset (== n_vertices) up to 65535; past that
+    both BLOBs switch to uint32. The reader (water_db.py) applies the
+    same threshold to the vertex count it already decodes, so the
+    choice is recoverable from the row itself."""
+    return np.uint32 if n_vertices > 65535 else np.uint16
+
+
 def tessellate_polygon(vertices, ring_ends=None):
     """Triangulate a polygon via earcut. Returns a numpy array of
-    uint16 indices (3 per triangle) into ``vertices``, or None if the
+    indices (3 per triangle) into ``vertices``, or None if the
     input is degenerate / fails tessellation.
 
     ``vertices`` is a list of (lat, lon) tuples — earcut sees them
@@ -74,10 +84,14 @@ def tessellate_polygon(vertices, ring_ends=None):
         return None
     if idx.size == 0 or (idx.size % 3) != 0:
         return None
-    # uint16 caps us at 65535 vertices per polygon — rings are
-    # decimated to <=32 vertices each at build time and insert_polygon
-    # refuses multi-ring rows past the uint16 range, so this is safe.
-    return idx.astype(np.uint16)
+    # Index dtype is implied by the row's vertex count: uint16 while
+    # every index AND ring-end offset fits (<= 65535 vertices), uint32
+    # beyond that. The reader derives the identical rule from the
+    # vertices BLOB length, so dense rows need no schema flag. The old
+    # builder silently DROPPED all holes past the uint16 ceiling — a
+    # dense cell like the lower Florida Keys (3,322 island rings) lost
+    # every island and #44 persisted there (oracle-gate residual B).
+    return idx.astype(_index_dtype(len(vertices)))
 
 
 SCHEMA = """
@@ -91,14 +105,18 @@ CREATE TABLE IF NOT EXISTS water_polygons (
     elev_ft   REAL,
     vertices  BLOB NOT NULL,
     -- Pre-tessellated triangle indices into the ``vertices`` array,
-    -- packed as little-endian uint16 (3 indices per triangle). NULL
-    -- only when tessellation failed at build time (logged as a
-    -- warning). The GPU water renderer uploads these directly to a
-    -- GL element-array buffer with one draw call per polygon.
+    -- packed little-endian (3 indices per triangle): uint16 for rows
+    -- of <= 65535 vertices, uint32 beyond (dense multi-ring cells;
+    -- the dtype is implied by the row's vertex count on both the
+    -- build and read side). NULL only when tessellation failed at
+    -- build time (logged as a warning). The GPU water renderer
+    -- uploads these directly to a GL element-array buffer with one
+    -- draw call per polygon.
     triangles BLOB,
     -- Ring topology for multi-ring (outer + hole) polygons, packed as
-    -- little-endian uint16 ring END offsets into ``vertices`` (earcut
-    -- convention: outer ring first, then each hole ring). NULL for
+    -- little-endian ring END offsets into ``vertices`` (earcut
+    -- convention: outer ring first, then each hole ring; same
+    -- uint16/uint32 vertex-count rule as ``triangles``). NULL for
     -- plain single-ring polygons — the overwhelming majority. When
     -- present, ``triangles`` was tessellated hole-aware, so island
     -- holes are excluded from the fill (#44).
@@ -294,20 +312,13 @@ def insert_polygon(con, kind, elev_ft, vertices, max_vertices=None,
     for h in holes:
         all_verts.extend(h)
         ring_ends.append(len(all_verts))
-    if len(all_verts) > 65535:
-        # uint16 triangle-index ceiling — drop the holes rather than
-        # store corrupt indices (only reachable with the vertex cap
-        # disabled on a pathological polygon).
-        print(f"  WARNING: {len(all_verts)} vertices exceeds the uint16 "
-              "index range; dropping holes for this polygon",
-              file=sys.stderr)
-        all_verts = list(vertices)
-        ring_ends = [len(vertices)]
-        holes = []
     # Pre-tessellate. The renderer reads these indices directly into a
     # GL element-array buffer at draw time — keeps per-frame Python
     # work down to a buffer upload + glDrawElements call. Hole-aware:
     # earcut subtracts the hole rings so islands are not filled (#44).
+    # Rows past 65535 vertices store uint32 indices instead of losing
+    # their holes (the old drop-the-holes fallback re-created #44 in
+    # exactly the densest island cells).
     tri_idx = tessellate_polygon(all_verts,
                                  ring_ends if holes else None)
     if tri_idx is None and holes:
@@ -319,8 +330,10 @@ def insert_polygon(con, kind, elev_ft, vertices, max_vertices=None,
         ring_ends = [len(vertices)]
         holes = []
         tri_idx = tessellate_polygon(all_verts)
-    tri_blob = tri_idx.tobytes() if tri_idx is not None else None
-    rings_blob = (np.asarray(ring_ends, dtype=np.uint16).tobytes()
+    idx_dtype = _index_dtype(len(all_verts))
+    tri_blob = (np.asarray(tri_idx, dtype=idx_dtype).tobytes()
+                if tri_idx is not None else None)
+    rings_blob = (np.asarray(ring_ends, dtype=idx_dtype).tobytes()
                   if holes else None)
     cur = con.execute(
         "INSERT INTO water_polygons "


### PR DESCRIPTION
﻿## What / why

Fixes #44 (test case #43): islands that are interior (hole) rings of water multipolygons -- the Florida Keys, barrier islands, lake islands -- rendered as ocean. Both live mechanisms are fixed at the build layer:

1. **Outer ring filled solid** -- tessellation was single-ring, so the hole was never subtracted from the ocean fill.
2. **Hole emitted as its own filled polygon** -- the ingest wrote every ring of a multipolygon as a separate filled `water_polygons` row.

## Design choice (as required by the backlog item)

**Hole-aware polygons**, not row-level even-odd grouping: one row per OUTER ring; hole rings ride in the same row (`vertices` = outer + holes concatenated, new nullable `rings` uint16 end-offset BLOB, earcut convention), and `triangles` is tessellated with the holes subtracted. Rationale: the GPU water renderer draws each row's pre-tessellated triangles with no cross-row state, so hole-awareness must live inside the row's tessellation anyway; grouping across rows would need renderer-side pairing state that does not exist. Ring classification is by shapefile winding (outer = CW in lon/lat = negative shoelace area; hole = CCW), which issue #44's probe confirmed survives ingest; holes are assigned to the smallest containing outer (handles nesting).

Fallbacks keep every winding-untrustworthy source on pre-#44 behavior: single-ring shapes import as outers regardless of winding (Natural Earth lakes, the text format); a multi-ring shape with no CW ring fills every ring; an orphan hole is dropped, never filled; failed hole-aware tessellation falls back to the outer ring alone.

## SCHEMA CHANGE FLAG (live /data contract)

Additive, nullable `rings` column in `water_polygons` (probe-based read, same pattern as `triangles`):
- **Old pack + new code**: fully compatible; `rings` is None everywhere, behavior unchanged (islands stay wrong until the pack is rebuilt).
- **New pack + old code**: degrades on multi-ring rows only -- old readers treat the concatenated vertex list as one outline. **Ship the water-pack rebuild together with (or after) the code update, not before.**
- Multi-ring rows bypass the reader-side vertex cap (re-decimation would corrupt ring offsets + triangle indices); the build-time PER-RING cap is the bound.

## Consumer changes (construct-never-raises preserved everywhere)

- `WaterDB`: decodes `rings`, `WaterPolygon.rings` + `outer_vertices`; no re-decimation of multi-ring rows. Construction/probing unchanged in shape.
- SVS GL water: **no change needed for built packs** (stored triangles are hole-aware). Defensive: the no-triangles fan fallback now fans the outer ring alone for multi-ring rows instead of fanning across rings.
- Moving map `_draw_water`: even-odd `QPainterPath` fill for multi-ring rows (fixes the same island bug on the map); single-ring rows keep the `drawPolygon` fast path.

## Self-review notes (scrutinize these)

1. **Winding classification trust boundary** -- the fix rests on shapefile winding surviving ingest (confirmed for the OSM water-polygons product by the #44 sweep). A source with broken winding falls back to fill-everything (safe, pre-#44 behavior), but a source with *inverted* winding would classify outers as holes and drop them via the orphan path. Worth a sanity count on the first real rebuild (the builder prints imported/hole/orphan counts).
2. **Hole-assignment cost** -- hole grouping is O(holes x outers) per shape with a bbox pre-filter, pure Python. Fine for the split OSM product (few rings per shape); if a full-continent rebuild is slow, this loop is the suspect.
3. **`_decode_vertices` cap bypass for multi-ring rows** -- deliberate (see schema flag). If a future pack is built with `--max-vertices 0`, multi-ring rows are unbounded at read time.

## Test evidence

- `tests/tools/test_build_water_db.py` (NEW, 11 tests) -- winding signs, hole grouping (containment, orphan drop, nesting, all-CCW fallback), and the DoD acceptance test: synthetic island-in-water multipolygon -> stored row count is 1 (hole not emitted as filled row) and point-in-stored-triangles says island interior is NOT water while the surrounding ring IS; pyshp end-to-end shapefile import; WaterDB read-back intact. **11 passed** locally (Windows).
- `tests/instruments/ai/test_svs.py` -- 3 new tests (multi-ring decode + no re-decimation, pre-#44 DB back-compat, collector outer-ring fan fallback). **Full file: 53 passed, 1 skipped** locally.
- `tests/instruments/test_moving_map.py` -- new `test_terrain_water_island_hole_stays_land` (water ring blue, island centre land, outside land). **10 passed** locally; the 3 `roads` tests crash with a pre-existing Windows access violation that reproduces on pristine `dev` (verified via stash) -- environmental, covered by CI on Linux.
- CI now actually runs the builder tests: new `watertools` extra (mapbox-earcut + pyshp, build-time only) installed in the test job.

## Out of scope / noticed

- **Full-continent water-pack rebuild and on-Pi KEYW visual check (#43) are daytime follow-ups** -- this PR is the builder/reader fix only; the flying pack still has the bug until rebuilt (`tools/svs_capture.py` repro in #44 is the acceptance check).
- #77 shares this root cause per the #44 comment -- retest after the pack rebuild.
- The old `ring_area_km2` size filter now applies to outer rings only; holes are never size-filtered (dropping a hole fills its island).
- B4 (rivers as waterway lines, #39) touches this same builder -- its branch should start from this one if this is still in review.

---

## Amendment (2026-07-18 overnight): oracle-gate residuals A + B

The 2026-07-18 oracle gate on this PR returned REQUEST CHANGES: the fix was ~90% effective at the middle Keys but left two residual defect classes in the hole-aware builder path. Both are fixed by the three amendment commits (52183ac, 5857d1a, 85d9056).

### Residual B -- uint16 index ceiling silently dropped ALL holes

Rows whose rings total more than 65535 vertices used to DROP every hole rather than store indices uint16 cannot hold. The lower-Keys cell carries 3,322 island rings -- 3,322 x 32 verts already overflows -- so #44 persisted at the exact test-case location (#43) and pack-truth checks were blind there.

**Design choice: uint32 triangle/ring indices, dtype implied by the row's vertex count** (uint16 iff <= 65535 vertices). The reader already knows the vertex count from the `vertices` BLOB length, so both sides derive the dtype from the same rule -- no schema flag, no new column, rows stay self-describing. Note the `rings` end-offset blob has the same overflow (the final offset equals the vertex count), so BOTH blobs follow the rule. The alternative (splitting dense cells into multiple rows) needs real polygon clipping -- holes crossing a cut line become boundary indentations, duplicated outers un-subtract each other's islands under painter's-algorithm overdraw -- and was rejected as heavy machinery for a data-width problem.

**Pack-size cost**: dense rows store 4-byte indices (2x triangle+ring blob width) AND keep the hole vertices that were previously dropped. Only rows past the ceiling pay it; the overwhelming majority stays uint16. The 3,322-ring Keys cell grows from outer-ring-only (~0.5 KB) to its full ring set (~2 MB at cap 32); national totals to be measured at the daytime rebuild.

**Compat (flagged prominently, same as the rings column)**: old packs read unchanged under new code (no old row exceeds the ceiling, by the old drop rule). A NEW pack's dense rows under OLD readers would mis-decode uint32 blobs as uint16 -- **deploy this code first, publish the pack rebuild after** (already the planned order: rebuild + gate rerun are daytime follow-ups).

### Residual A -- tessellation covered ~7% of hole interiors (54/770 in the Keys probe)

Root cause per the gate's suspicion, now defended against directly: per-ring decimation runs before earcut, and an aggressively simplified ring can self-intersect or cross its outer ring -- earcut then FILLS the hole instead of subtracting it.

`insert_polygon` now **verifies every multi-ring row after tessellation**: interior points of each hole (even-odd scanline midpoints) are tested against the stored fill triangles -- judged on exactly what the renderer will draw. On failure the decimation cap escalates (doubling to 512, then the raw source rings); if raw still fails, triangles whose centroid lands in a hole are stripped as a last resort (biased toward LAND -- painting an island as water is the dangerous direction for an EFIS). Unresolved rows warn on stderr; `import_shapefile` prints escalated / stripped / unresolved counts per source file. Single-ring rows (the overwhelming majority) skip verification entirely.

### Amendment self-review notes (scrutinize these)

1. **The dtype rule is inferred, not declared.** Any third consumer that decodes `triangles`/`rings` without the vertex-count rule will mis-read dense rows. Known consumers (WaterDB -> SVS GL water + moving map) all go through `_decode_triangles`/`_decode_rings`.
2. **Verification samples, not proofs.** Up to 3 interior points per hole (scanline midpoints); a fill covering a hole only away from all samples would pass. The oracle's independent pack-truth sweep at the gate rerun is the real acceptance.
3. **Escalation vs blob size.** A row that only verifies at raw rings stores undecimated geometry (unbounded BLOB). Counted and printed at build time -- if the national rebuild reports many escalated rows, revisit the ladder bound.

### Amendment test evidence

`tests/tools/test_build_water_db.py` grew 11 -> 20 tests, all passing locally (Windows):

- `TestDenseCellUint32` (4): synthetic 66,004-vertex multipolygon (300 island holes, past the uint16 ceiling) -- the row keeps ALL holes; blobs are 4-byte little-endian with valid indices actually referencing vertices past 65535; **full sweep: 1,500 island interior samples all dry, water between islands wet**; WaterDB round-trip intact with no re-decimation.
- `TestHoleVerification` (5): interior-point generator stays in-ring (convex + concave); the detector flags a hole-covering fan and passes a correct hole-aware fill; escalation recovers from a bad first tessellation (stats recorded, stored row verified dry); the strip fallback removes a rogue in-hole triangle when every cap including raw fails.

`tests/instruments/ai/`: 161 passed; 4 pre-existing Windows path-separator failures (identical with the amendment reverted). Full suite: the known intermittent Windows access violation in the moving-map roads tests reproduces identically at the pre-amendment commit -- environmental; Linux CI is the arbiter.

Final acceptance = daytime oracle-gate rerun (B6 pattern) before merge, then the pack rebuild.
